### PR TITLE
TB-93: Updates dependencies for loc_scraper

### DIFF
--- a/loc_scraper.gemspec
+++ b/loc_scraper.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mechanize', '~> 2.8.0'
-  gem.add_dependency 'mime-types', '~> 3.0.0'
+  gem.add_dependency 'mechanize', '~> 2.7'
+  gem.add_dependency 'mime-types', '~> 3.0'
 
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake', '~> 10'

--- a/loc_scraper.gemspec
+++ b/loc_scraper.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mechanize', '~> 2.7'
-  gem.add_dependency 'mime-types', '~> 1.25'
+  gem.add_dependency 'mechanize', '~> 2.8.0'
+  gem.add_dependency 'mime-types', '~> 3.0.0'
 
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
## What
We needed to upgrade the `mechanize` dependency inside this gem. The version of `mechanize` that was installed inside another project had a security vulnerability. 

## QA Notes

I tested this by running `bundle install` and then `rake` to run the specs. All specs passed.