### PR TITLE
TB-93: Update mime-types constraint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.0] - 2024-05-09
+### Changed
+- Updated mime-types dependency constraint to '~> 3.0'
+
 ## [0.0.3] - 2016-09-02
 ### Changed
 - Updated scraping to match new html tags on LOC site

--- a/lib/loc_scraper/version.rb
+++ b/lib/loc_scraper/version.rb
@@ -1,3 +1,3 @@
 module LocScraper
-  VERSION = '0.0.3'
+  VERSION = '0.1.0'
 end

--- a/loc_scraper.gemspec
+++ b/loc_scraper.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'mechanize', '~> 2.7'
-  gem.add_dependency 'mime-types', '~> 1.25'
+  gem.add_dependency 'mime-types', '~> 3.0'
 
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
### What
We needed to upgrade the mechanize dependency inside this gem. The version of mechanize that was installed inside another project had a security vulnerability.

### QA Notes
I tested this by running bundle install and then rake to run the specs. All specs passed.